### PR TITLE
Fix #11 - Add Open311 endpoints for each region

### DIFF
--- a/staging/regions-v3.json
+++ b/staging/regions-v3.json
@@ -8,6 +8,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.11-SNAPSHOT|1|1|11|SNAPSHOT|6950d86123a7a9e5f12065bcbec0c516f35d86d9", 
         "supportsSiriRealtimeApis": true, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "http://mobile.twitter.com/OBA_tampa", 
         "supportsObaRealtimeApis": true, 
@@ -19,7 +20,18 @@
             "lonSpan": 0.576357999999999
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [
+          {
+            "juridisctionId": null, 
+            "apiKey": "937033cad3054ec58a1a8156dcdd6ad8a416af2f", 
+            "baseUrl": "http://test.seeclickfix.com/open311/v2/"
+          }, 
+          {
+            "juridisctionId": null, 
+            "apiKey": "937033cad3054ec58a1a8156dcdd6ad8a416af2f", 
+            "baseUrl": "http://www.publicstuff.com/api/open311/"
+          }
+        ], 
         "contactEmail": "onebusaway@gohart.org", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -33,6 +45,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.7|1|1|7||c8ee3d4906dd55ecafdd124f31f39c0f54a37b52", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "http://mobile.twitter.com/oba_pugetsound", 
         "supportsObaRealtimeApis": true, 
@@ -92,7 +105,7 @@
             "lonSpan": 0.784555996061
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "onebusaway@soundtransit.org", 
         "stopInfoUrl": "http://stopinfo.pugetsound.onebusaway.org", 
         "active": true, 
@@ -106,6 +119,7 @@
         "siriBaseUrl": "http://bustime.mta.info/api/", 
         "obaVersionInfo": "", 
         "supportsSiriRealtimeApis": true, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "http://mobile.twitter.com/nyctbusstop", 
         "supportsObaRealtimeApis": false, 
@@ -123,7 +137,7 @@
             "lonSpan": 0.23146799999999246
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "MTABusTime@mtahq.org", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -137,6 +151,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.14-SNAPSHOT|1|1|14|SNAPSHOT|440e5cb692a1ed195de7f0686d69f5ceecbe9a41", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "http://mobile.twitter.com/OBA_atlanta", 
         "supportsObaRealtimeApis": true, 
@@ -184,7 +199,7 @@
             "lonSpan": 0.5820399999999921
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "onebusaway@ce.gatech.edu", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -198,6 +213,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "", 
         "supportsObaRealtimeApis": true, 
@@ -215,7 +231,7 @@
             "lonSpan": 0.10683699999999874
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "kurt@kurtraschke.com", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -229,6 +245,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.7|1|1|7||c8ee3d4906dd55ecafdd124f31f39c0f54a37b52", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_CA", 
         "twitterUrl": "https://mobile.twitter.com/YRTViva", 
         "supportsObaRealtimeApis": true, 
@@ -240,7 +257,7 @@
             "lonSpan": 0.49329600000000084
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "transitinfo@york.ca", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -254,6 +271,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.7|1|1|7|d3bbb9109a652359845bdee516dc2cbd1ba35e49", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "https://mobile.twitter.com/CalParking", 
         "supportsObaRealtimeApis": true, 
@@ -265,7 +283,7 @@
             "lonSpan": 0.10181500000000199
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "bear-transit@v-a.io", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -279,6 +297,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "", 
         "supportsObaRealtimeApis": true, 
@@ -296,7 +315,7 @@
             "lonSpan": 1.1692720000000065
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "sbrown@camsys.com", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -310,6 +329,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.13|1|1|13||ef9f836500eafee955381b17799b3105b525e93b", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "fi_FI", 
         "twitterUrl": "", 
         "supportsObaRealtimeApis": true, 
@@ -321,7 +341,7 @@
             "lonSpan": 0.2674852336517013
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "obasupport@octo3.fi", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -335,6 +355,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "", 
         "supportsObaRealtimeApis": true, 
@@ -346,7 +367,7 @@
             "lonSpan": 0.2974530000000044
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "info@rvtd.org", 
         "stopInfoUrl": null, 
         "active": true, 

--- a/staging/regions-v3.xml
+++ b/staging/regions-v3.xml
@@ -23,6 +23,18 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>onebusaway@gohart.org</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers>
+          <open311Server>
+            <juridisctionId></juridisctionId>
+            <apiKey>937033cad3054ec58a1a8156dcdd6ad8a416af2f</apiKey>
+            <baseUrl>http://test.seeclickfix.com/open311/v2/</baseUrl>
+          </open311Server>
+          <open311Server>
+            <juridisctionId></juridisctionId>
+            <apiKey>937033cad3054ec58a1a8156dcdd6ad8a416af2f</apiKey>
+            <baseUrl>http://www.publicstuff.com/api/open311/</baseUrl>
+          </open311Server>
+        </open311Servers>
         <active>true</active>
         <facebookUrl></facebookUrl>
         <obaBaseUrl>http://api.tampa.onebusaway.org/api/</obaBaseUrl>
@@ -96,6 +108,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>onebusaway@soundtransit.org</contactEmail>
         <stopInfoUrl>http://stopinfo.pugetsound.onebusaway.org</stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl>https://www.facebook.com/pages/OneBusAway/216091804930</facebookUrl>
         <obaBaseUrl>http://api.pugetsound.onebusaway.org/</obaBaseUrl>
@@ -127,6 +140,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>MTABusTime@mtahq.org</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl>https://www.facebook.com/pages/MTA-New-York-City-Transit/232635164606</facebookUrl>
         <obaBaseUrl>http://bustime.mta.info/</obaBaseUrl>
@@ -188,6 +202,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>onebusaway@ce.gatech.edu</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl>https://www.facebook.com/pages/ObaAtlanta/136662306506627</facebookUrl>
         <obaBaseUrl>http://atlanta.onebusaway.org/api/</obaBaseUrl>
@@ -219,6 +234,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>kurt@kurtraschke.com</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl></facebookUrl>
         <obaBaseUrl>http://developer.onebusaway.org/wmata-api/</obaBaseUrl>
@@ -244,6 +260,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>transitinfo@york.ca</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl>https://www.facebook.com/198178906967045</facebookUrl>
         <obaBaseUrl>http://oba.yrt.ca/</obaBaseUrl>
@@ -269,6 +286,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>bear-transit@v-a.io</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl>https://www.facebook.com/pages/Bear-Transit/109669175726418</facebookUrl>
         <obaBaseUrl>http://bt.v-a.io/onebusaway/</obaBaseUrl>
@@ -300,6 +318,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>sbrown@camsys.com</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl></facebookUrl>
         <obaBaseUrl>http://developer.onebusaway.org/mbta-api/</obaBaseUrl>
@@ -325,6 +344,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>obasupport@octo3.fi</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl></facebookUrl>
         <obaBaseUrl>http://194.89.230.196:8080/</obaBaseUrl>
@@ -350,6 +370,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>info@rvtd.org</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl></facebookUrl>
         <obaBaseUrl>http://oba.rvtd.org:8080/onebusaway-api-webapp/</obaBaseUrl>

--- a/staging/regions.json
+++ b/staging/regions.json
@@ -8,6 +8,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.11-SNAPSHOT|1|1|11|SNAPSHOT|6950d86123a7a9e5f12065bcbec0c516f35d86d9", 
         "supportsSiriRealtimeApis": true, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "http://mobile.twitter.com/OBA_tampa", 
         "supportsObaRealtimeApis": true, 
@@ -19,7 +20,18 @@
             "lonSpan": 0.576357999999999
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [
+          {
+            "juridisctionId": null, 
+            "apiKey": "937033cad3054ec58a1a8156dcdd6ad8a416af2f", 
+            "baseUrl": "http://test.seeclickfix.com/open311/v2/"
+          }, 
+          {
+            "juridisctionId": null, 
+            "apiKey": "937033cad3054ec58a1a8156dcdd6ad8a416af2f", 
+            "baseUrl": "http://www.publicstuff.com/api/open311/"
+          }
+        ], 
         "contactEmail": "onebusaway@gohart.org", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -33,6 +45,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.7|1|1|7||c8ee3d4906dd55ecafdd124f31f39c0f54a37b52", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "http://mobile.twitter.com/oba_pugetsound", 
         "supportsObaRealtimeApis": true, 
@@ -92,7 +105,7 @@
             "lonSpan": 0.784555996061
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "onebusaway@soundtransit.org", 
         "stopInfoUrl": "http://stopinfo.pugetsound.onebusaway.org", 
         "active": true, 
@@ -106,6 +119,7 @@
         "siriBaseUrl": "http://bustime.mta.info/api/", 
         "obaVersionInfo": "", 
         "supportsSiriRealtimeApis": true, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "http://mobile.twitter.com/nyctbusstop", 
         "supportsObaRealtimeApis": false, 
@@ -123,7 +137,7 @@
             "lonSpan": 0.23146799999999246
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "MTABusTime@mtahq.org", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -137,6 +151,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.14-SNAPSHOT|1|1|14|SNAPSHOT|440e5cb692a1ed195de7f0686d69f5ceecbe9a41", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "http://mobile.twitter.com/OBA_atlanta", 
         "supportsObaRealtimeApis": true, 
@@ -184,7 +199,7 @@
             "lonSpan": 0.5820399999999921
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "onebusaway@ce.gatech.edu", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -198,6 +213,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "1.1.7|1|1|7||c8ee3d4906dd55ecafdd124f31f39c0f54a37b52", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_CA", 
         "twitterUrl": "https://mobile.twitter.com/YRTViva", 
         "supportsObaRealtimeApis": true, 
@@ -209,7 +225,7 @@
             "lonSpan": 0.49329600000000084
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "transitinfo@york.ca", 
         "stopInfoUrl": null, 
         "active": true, 
@@ -223,6 +239,7 @@
         "siriBaseUrl": null, 
         "obaVersionInfo": "", 
         "supportsSiriRealtimeApis": false, 
+        "supportsObaDiscoveryApis": true, 
         "language": "en_US", 
         "twitterUrl": "", 
         "supportsObaRealtimeApis": true, 
@@ -234,7 +251,7 @@
             "lonSpan": 0.2974530000000044
           }
         ], 
-        "supportsObaDiscoveryApis": true, 
+        "open311Servers": [], 
         "contactEmail": "info@rvtd.org", 
         "stopInfoUrl": null, 
         "active": true, 

--- a/staging/regions.xml
+++ b/staging/regions.xml
@@ -23,6 +23,18 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>onebusaway@gohart.org</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers>
+          <open311Server>
+            <juridisctionId></juridisctionId>
+            <apiKey>937033cad3054ec58a1a8156dcdd6ad8a416af2f</apiKey>
+            <baseUrl>http://test.seeclickfix.com/open311/v2/</baseUrl>
+          </open311Server>
+          <open311Server>
+            <juridisctionId></juridisctionId>
+            <apiKey>937033cad3054ec58a1a8156dcdd6ad8a416af2f</apiKey>
+            <baseUrl>http://www.publicstuff.com/api/open311/</baseUrl>
+          </open311Server>
+        </open311Servers>
         <active>true</active>
         <facebookUrl></facebookUrl>
         <obaBaseUrl>http://api.tampa.onebusaway.org/api/</obaBaseUrl>
@@ -96,6 +108,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>onebusaway@soundtransit.org</contactEmail>
         <stopInfoUrl>http://stopinfo.pugetsound.onebusaway.org</stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl>https://www.facebook.com/pages/OneBusAway/216091804930</facebookUrl>
         <obaBaseUrl>http://api.pugetsound.onebusaway.org/</obaBaseUrl>
@@ -127,6 +140,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>MTABusTime@mtahq.org</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl>https://www.facebook.com/pages/MTA-New-York-City-Transit/232635164606</facebookUrl>
         <obaBaseUrl>http://bustime.mta.info/</obaBaseUrl>
@@ -188,6 +202,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>onebusaway@ce.gatech.edu</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl>https://www.facebook.com/pages/ObaAtlanta/136662306506627</facebookUrl>
         <obaBaseUrl>http://atlanta.onebusaway.org/api/</obaBaseUrl>
@@ -213,6 +228,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>transitinfo@york.ca</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl>https://www.facebook.com/198178906967045</facebookUrl>
         <obaBaseUrl>http://oba.yrt.ca/</obaBaseUrl>
@@ -238,6 +254,7 @@
         <supportsObaDiscoveryApis>true</supportsObaDiscoveryApis>
         <contactEmail>info@rvtd.org</contactEmail>
         <stopInfoUrl></stopInfoUrl>
+        <open311Servers/>
         <active>true</active>
         <facebookUrl></facebookUrl>
         <obaBaseUrl>http://oba.rvtd.org:8080/onebusaway-api-webapp/</obaBaseUrl>


### PR DESCRIPTION
Open311 endpoints added to OBA Region API.

```
"open311Servers": [

{

    "juridisctionId": null,
    "apiKey": "937033cad3054ec58a1a8156dcdd6ad8a416af2f",
    "baseUrl": "http://test.seeclickfix.com/open311/v2/"

},

    {
        "juridisctionId": null,
        "apiKey": "937033cad3054ec58a1a8156dcdd6ad8a416af2f",
        "baseUrl": "http://www.publicstuff.com/api/open311/"
    }

],
```